### PR TITLE
Fixed: Fix model simplify limit

### DIFF
--- a/src/lunarmp/model/ModelSimplification.cpp
+++ b/src/lunarmp/model/ModelSimplification.cpp
@@ -93,8 +93,13 @@ void ModelSimplification::modelSimplification(std::string input_file, std::strin
         }
         case SimplifyType::EDGE_RATIO_STOP: {
             auto edge_ratio_threshold = data_group.settings.get<double>("edge_ratio_threshold");
-//            edgeCollapseGarlandHeckbert(mesh, edge_ratio_threshold);
-            edgeCollapseBoundedNormalChange(mesh, mesh.edges().size() * edge_ratio_threshold);
+            double edge_count_threshold = mesh.number_of_edges() * edge_ratio_threshold;
+            if (edge_count_threshold < 1000) {
+                edgeCollapseGarlandHeckbert(mesh, edge_ratio_threshold);
+            }
+            else {
+                edgeCollapseBoundedNormalChange(mesh, edge_count_threshold);
+            }
             simplification_time = t.time();
             break;
         }


### PR DESCRIPTION
Fixed：Modified the rule of simplifying by the number of edges of the model. Models with less than 1000 edges will be executed according to a more strict simplified logic